### PR TITLE
feat: Implement Java file organizer and PDF reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# JAVA_LINUX
+# Java File Organizer
+
+This program organizes files in a specified directory by moving them into subdirectories based on the first four characters of their filenames. It also generates a PDF report of the operations performed.
+
+## Features
+
+- Reads files from `/home/gerente-ti/salidas`.
+- Creates subdirectories within `/home/gerente-ti/salidas` named after the first four characters of each file.
+- Moves files into their respective subdirectories.
+- Generates a PDF report named `report.pdf` in `/home/gerente-ti/salidas` detailing the actions taken.
+
+## Prerequisites
+
+- Java Development Kit (JDK) 8 or higher.
+- Apache Maven.
+
+## Dependencies
+
+- Apache PDFBox (for PDF report generation). This is managed by Maven.
+
+## Building the Application
+
+1.  Navigate to the project's root directory (where `pom.xml` is located).
+2.  Compile the project and create an executable JAR with dependencies:
+    ```bash
+    mvn compile assembly:single
+    ```
+    This will generate a JAR file in the `target/` directory (e.g., `file-organizer-1.0-SNAPSHOT-jar-with-dependencies.jar`).
+
+## Running the Application
+
+1.  Ensure the input directory `/home/gerente-ti/salidas` exists and contains files you want to organize.
+2.  Open a terminal or command prompt.
+3.  Navigate to the project's root directory.
+4.  Run the application using the following command (replace the JAR filename if it's different):
+    ```bash
+    java -jar target/file-organizer-1.0-SNAPSHOT-jar-with-dependencies.jar
+    ```
+5.  The program will process the files and generate a `report.pdf` in `/home/gerente-ti/salidas`. A confirmation message will be printed to the console.
+
+## Important Notes
+
+- The input directory `/home/gerente-ti/salidas` is currently hardcoded in the application.
+- The PDF report `report.pdf` is saved in the `/home/gerente-ti/salidas` directory.
+- Ensure the application has the necessary read/write permissions for the target directory and its subdirectories.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>file-organizer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.27</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.example.fileorganizer.FileOrganizer</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/fileorganizer/FileOrganizer.java
+++ b/src/main/java/com/example/fileorganizer/FileOrganizer.java
@@ -1,0 +1,134 @@
+package com.example.fileorganizer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+
+// PDFBox Imports
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+
+public class FileOrganizer {
+
+    private static final String TARGET_DIRECTORY = "/home/gerente-ti/salidas";
+    private static final String REPORT_FILE_NAME = "report.pdf";
+    private static List<String> movedFilesLog = new ArrayList<>();
+
+    public static void main(String[] args) {
+        File mainDir = new File(TARGET_DIRECTORY);
+
+        if (!mainDir.exists() || !mainDir.isDirectory()) {
+            System.err.println("Error: The directory " + TARGET_DIRECTORY + " does not exist or is not a directory.");
+            return;
+        }
+
+        File[] files = mainDir.listFiles();
+
+        if (files == null) {
+            System.err.println("Error: Could not list files in " + TARGET_DIRECTORY + ". Check permissions.");
+            return;
+        }
+
+        for (File file : files) {
+            if (file.isFile()) {
+                processFile(file, mainDir.toPath());
+            }
+        }
+
+        System.out.println("\n--- File Processing Complete ---");
+        // No longer printing log here, it will go to the PDF
+        
+        String reportOutputPath = Paths.get(TARGET_DIRECTORY, REPORT_FILE_NAME).toString();
+        generatePdfReport(movedFilesLog, reportOutputPath);
+
+        // Placeholder for actual alert
+        System.out.println("Alert: File organization process finished. Report generated at " + reportOutputPath);
+    }
+
+    private static void processFile(File file, Path baseDir) {
+        String fileName = file.getName();
+        if (fileName.length() >= 4) {
+            String subDirName = fileName.substring(0, 4).toUpperCase();
+            Path subDirPath = baseDir.resolve(subDirName);
+
+            try {
+                if (!Files.exists(subDirPath)) {
+                    Files.createDirectories(subDirPath);
+                    String log = "Created directory: " + subDirPath;
+                    System.out.println(log);
+                    movedFilesLog.add(log);
+                }
+
+                Path sourcePath = file.toPath();
+                Path destinationPath = subDirPath.resolve(fileName);
+                Files.move(sourcePath, destinationPath, StandardCopyOption.REPLACE_EXISTING);
+                String logMessage = "Moved file: " + fileName + " to " + subDirName + File.separator + fileName;
+                System.out.println(logMessage);
+                movedFilesLog.add(logMessage);
+
+            } catch (IOException e) {
+                String errorLog = "Error processing file " + fileName + ": " + e.getMessage();
+                System.err.println(errorLog);
+                movedFilesLog.add(errorLog);
+            }
+        } else {
+            String logMessage = "File name " + fileName + " is less than 4 characters long. Skipping.";
+            System.out.println(logMessage);
+            movedFilesLog.add(logMessage);
+        }
+    }
+
+    private static void generatePdfReport(List<String> logEntries, String outputPath) {
+        try (PDDocument document = new PDDocument()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.setFont(PDType1Font.HELVETICA_BOLD, 16);
+                contentStream.beginText();
+                contentStream.newLineAtOffset(50, 750);
+                contentStream.showText("File Organization Report");
+                contentStream.endText();
+
+                contentStream.setFont(PDType1Font.HELVETICA, 10);
+                float yPosition = 720;
+                float leading = 14.5f; // Line spacing
+
+                for (String entry : logEntries) {
+                    if (yPosition < 50) { // Check if new page is needed
+                        contentStream.endText(); // End text on current page before closing stream
+                        contentStream.close();
+                        page = new PDPage();
+                        document.addPage(page);
+                        contentStream = new PDPageContentStream(document, page); // new content stream for new page
+                        contentStream.setFont(PDType1Font.HELVETICA, 10);
+                        yPosition = 750; // Reset Y position
+                        contentStream.beginText(); // Must begin text again for the new page
+                        contentStream.newLineAtOffset(50, yPosition);
+                    }
+                     if (!contentStream.isInTextMode()) { // Ensure we are in text mode
+                        contentStream.beginText();
+                        contentStream.newLineAtOffset(50, yPosition);
+                    }
+                    contentStream.showText(entry);
+                    contentStream.newLineAtOffset(0, -leading);
+                    yPosition -= leading;
+                }
+                contentStream.endText();
+            }
+            document.save(outputPath);
+            System.out.println("PDF report generated successfully at " + outputPath);
+            movedFilesLog.add("PDF report generated successfully at " + outputPath); // Add to log as well
+        } catch (IOException e) {
+            System.err.println("Error generating PDF report: " + e.getMessage());
+            movedFilesLog.add("Error generating PDF report: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new Java application that organizes files within a specified directory.

Key features:
- Reads files from /home/gerente-ti/salidas.
- Extracts the first four characters of each filename to determine a subdirectory name.
- Creates these subdirectories if they do not exist.
- Moves the files into their respective subdirectories.
- Generates a PDF report (report.pdf in /home/gerente-ti/salidas) detailing all file operations performed (creations, moves, errors).
- Prints an alert to the console upon completion.

The project uses Apache Maven for build management and includes Apache PDFBox for PDF generation. The README.md has been updated with build and run instructions.